### PR TITLE
Use `char` instead of `&str`, keep score at top left of frame

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,17 +1,9 @@
 use crate::{NUM_COLS, NUM_ROWS};
 
-pub type Frame = Vec<Vec<&'static str>>;
+pub type Frame = [[char; NUM_ROWS]; NUM_COLS];
 
 pub fn new_frame() -> Frame {
-    let mut cols = Vec::with_capacity(NUM_COLS);
-    for _ in 0..NUM_COLS {
-        let mut col = Vec::with_capacity(NUM_ROWS);
-        for _ in 0..NUM_ROWS {
-            col.push(" ");
-        }
-        cols.push(col);
-    }
-    cols
+    [[' '; NUM_ROWS]; NUM_COLS]
 }
 
 pub trait Drawable {

--- a/src/invaders.rs
+++ b/src/invaders.rs
@@ -11,6 +11,7 @@ pub struct Invader {
 
 pub struct Invaders {
     pub army: Vec<Invader>,
+    pub total_count: usize,
     move_timer: Timer,
     direction: i32,
 }
@@ -31,8 +32,10 @@ impl Invaders {
                 }
             }
         }
+        let total_count = army.len();
         Self {
             army,
+            total_count,
             move_timer: Timer::from_millis(2000),
             direction: 1,
         }

--- a/src/invaders.rs
+++ b/src/invaders.rs
@@ -97,9 +97,9 @@ impl Drawable for Invaders {
                 / self.move_timer.duration.as_secs_f32())
                 > 0.5
             {
-                "x"
+                'x'
             } else {
-                "+"
+                '+'
             }
         }
     }

--- a/src/invaders.rs
+++ b/src/invaders.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 pub struct Invader {
     pub x: usize,
     pub y: usize,
+    points: u16,
 }
 
 pub struct Invaders {
@@ -28,7 +29,7 @@ impl Invaders {
                     && (x % 2 == 0)
                     && (y % 2 == 0)
                 {
-                    army.push(Invader { x, y });
+                    army.push(Invader { x, y, points: 1 });
                 }
             }
         }
@@ -79,16 +80,17 @@ impl Invaders {
     pub fn reached_bottom(&self) -> bool {
         self.army.iter().map(|invader| invader.y).max().unwrap_or(0) >= NUM_ROWS - 1
     }
-    pub fn kill_invader_at(&mut self, x: usize, y: usize) -> bool {
+    pub fn kill_invader_at(&mut self, x: usize, y: usize) -> u16 {
         if let Some(idx) = self
             .army
             .iter()
             .position(|invader| (invader.x == x) && (invader.y == y))
         {
+            let points = self.army[idx].points;
             self.army.remove(idx);
-            true
+            points
         } else {
-            false
+            0
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod frame;
 pub mod invaders;
 pub mod player;
 pub mod render;
+pub mod score;
 pub mod shot;
 
 pub const NUM_ROWS: usize = 20;

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,6 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         // Updates
         player.update(delta);
-        // score.update(&invaders);
         if invaders.update(delta) {
             audio.play("move");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,9 +83,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         if invaders.update(delta) {
             audio.play("move");
         }
-        if player.detect_hits(&mut invaders) {
+        let hits: u16 = player.detect_hits(&mut invaders);
+        if hits > 0 {
             audio.play("explode");
-            score.add_points(1);
+            score.add_points(hits);
         }
 
         // Draw & render

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use crossterm::{event, terminal, ExecutableCommand};
 use invaders::frame::{new_frame, Drawable};
 use invaders::invaders::Invaders;
 use invaders::player::Player;
+use invaders::score::Score;
 use invaders::{frame, render};
 use rusty_audio::Audio;
 use std::error::Error;
@@ -48,6 +49,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut player = Player::new();
     let mut instant = Instant::now();
     let mut invaders = Invaders::new();
+    let mut score = Score::new();
+
     'gameloop: loop {
         // Per-frame init
         let delta = instant.elapsed();
@@ -76,6 +79,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         // Updates
         player.update(delta);
+        score.update(&invaders);
         if invaders.update(delta) {
             audio.play("move");
         }
@@ -84,7 +88,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
 
         // Draw & render
-        let drawables: Vec<&dyn Drawable> = vec![&player, &invaders];
+        let drawables: Vec<&dyn Drawable> = vec![&player, &invaders, &score];
         for drawable in drawables {
             drawable.draw(&mut curr_frame);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,12 +79,13 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         // Updates
         player.update(delta);
-        score.update(&invaders);
+        // score.update(&invaders);
         if invaders.update(delta) {
             audio.play("move");
         }
         if player.detect_hits(&mut invaders) {
             audio.play("explode");
+            score.add_points(1);
         }
 
         // Draw & render

--- a/src/player.rs
+++ b/src/player.rs
@@ -42,12 +42,13 @@ impl Player {
         }
         self.shots.retain(|shot| !shot.dead());
     }
-    pub fn detect_hits(&mut self, invaders: &mut Invaders) -> bool {
-        let mut hit_something = false;
+    pub fn detect_hits(&mut self, invaders: &mut Invaders) -> u16 {
+        let mut hit_something = 0u16;
         for shot in self.shots.iter_mut() {
             if !shot.exploding {
-                if invaders.kill_invader_at(shot.x, shot.y) {
-                    hit_something = true;
+                let hit_count = invaders.kill_invader_at(shot.x, shot.y);
+                if hit_count > 0 {
+                    hit_something += hit_count;
                     shot.explode();
                 }
             }

--- a/src/player.rs
+++ b/src/player.rs
@@ -58,7 +58,7 @@ impl Player {
 
 impl Drawable for Player {
     fn draw(&self, frame: &mut Frame) {
-        frame[self.x][self.y] = "A";
+        frame[self.x][self.y] = 'A';
         for shot in self.shots.iter() {
             shot.draw(frame);
         }

--- a/src/score.rs
+++ b/src/score.rs
@@ -19,18 +19,10 @@ impl Drawable for Score {
         // format our score string
         let formated = format!("SCORE: {:0>4}", self.count);
 
-        // create a vector of chars to write each score char into
-        let mut chars = Vec::<char>::new();
-
-        // copy chars from formated string into the char vector
-        for c in formated.chars() {
-            chars.push(c);
-        }
-
         // iterate over all characters
-        for (i, c) in chars.iter().enumerate() {
+        for (i, c) in formated.chars().enumerate() {
             // put them in the first row
-            frame[i][0] = *c;
+            frame[i][0] = c;
         }
     }
 }

--- a/src/score.rs
+++ b/src/score.rs
@@ -1,0 +1,37 @@
+use crate::{
+    frame::{Drawable, Frame},
+    invaders::Invaders,
+};
+
+pub struct Score {
+    chars: Vec<char>,
+}
+
+impl Score {
+    pub fn new() -> Self {
+        Self { chars: Vec::new() }
+    }
+
+    pub fn update(&mut self, invaders: &Invaders) {
+        // format our score string
+        let formated = format!("SCORE: {:0>3}", invaders.total_count - invaders.army.len());
+
+        // clear the old score vector
+        self.chars.clear();
+
+        // copy chars from formated string into the char vector
+        for c in formated.chars() {
+            self.chars.push(c);
+        }
+    }
+}
+
+impl Drawable for Score {
+    fn draw(&self, frame: &mut Frame) {
+        // iterate over all characters
+        for (i, c) in self.chars.iter().enumerate() {
+            // put them in the first row
+            frame[i][0] = *c;
+        }
+    }
+}

--- a/src/score.rs
+++ b/src/score.rs
@@ -20,7 +20,7 @@ impl Drawable for Score {
         let formatted = format!("SCORE: {:0>4}", self.count);
 
         // iterate over all characters
-        for (i, c) in formated.chars().enumerate() {
+        for (i, c) in formatted.chars().enumerate() {
             // put them in the first row
             frame[i][0] = c;
         }

--- a/src/score.rs
+++ b/src/score.rs
@@ -1,35 +1,34 @@
-use crate::{
-    frame::{Drawable, Frame},
-    invaders::Invaders,
-};
+use crate::frame::{Drawable, Frame};
 
 pub struct Score {
-    chars: Vec<char>,
+    count: u16,
 }
 
 impl Score {
     pub fn new() -> Self {
-        Self { chars: Vec::new() }
+        Self { count: 0 }
     }
 
-    pub fn update(&mut self, invaders: &Invaders) {
-        // format our score string
-        let formated = format!("SCORE: {:0>3}", invaders.total_count - invaders.army.len());
-
-        // clear the old score vector
-        self.chars.clear();
-
-        // copy chars from formated string into the char vector
-        for c in formated.chars() {
-            self.chars.push(c);
-        }
+    pub fn add_points(&mut self, amount: u16) {
+        self.count += amount;
     }
 }
 
 impl Drawable for Score {
     fn draw(&self, frame: &mut Frame) {
+        // format our score string
+        let formated = format!("SCORE: {:0>4}", self.count);
+
+        // create a vector of chars to write each score char into
+        let mut chars = Vec::<char>::new();
+
+        // copy chars from formated string into the char vector
+        for c in formated.chars() {
+            chars.push(c);
+        }
+
         // iterate over all characters
-        for (i, c) in self.chars.iter().enumerate() {
+        for (i, c) in chars.iter().enumerate() {
             // put them in the first row
             frame[i][0] = *c;
         }

--- a/src/score.rs
+++ b/src/score.rs
@@ -17,7 +17,7 @@ impl Score {
 impl Drawable for Score {
     fn draw(&self, frame: &mut Frame) {
         // format our score string
-        let formated = format!("SCORE: {:0>4}", self.count);
+        let formatted = format!("SCORE: {:0>4}", self.count);
 
         // iterate over all characters
         for (i, c) in formated.chars().enumerate() {

--- a/src/shot.rs
+++ b/src/shot.rs
@@ -38,6 +38,6 @@ impl Shot {
 
 impl Drawable for Shot {
     fn draw(&self, frame: &mut Frame) {
-        frame[self.x][self.y] = if self.exploding { "*" } else { "|" };
+        frame[self.x][self.y] = if self.exploding { '*' } else { '|' };
     }
 }


### PR DESCRIPTION
I've added a simple score module in `score.rs` which implements the `Drawable` trait to print the current score in the top left corner of the `Frame`.

The score is simply calculated by subtracting `Invaders.army.len()` from  the newly introduced `Invaders.total_count` which represents the total count of spawned invaders in the army.

So each hit invader results in one point added on the score.

## Note
To make rendering easier I've refactored `Frame`s data structure into a 2d char array in the 
form of `[[char ; NUM_ROWS]; NUM_COLS]`.

This allows for the same access `frame[x][y]` but only takes `char` instead of `&str`.

It was done to enable the dynamic use of  `format!` in `Score.update` which returns a `String`.
That `String` is not easily convertable to `&str` especially given the different lifetimes.

This also gives the option to add more useful strings like "time played" or "level" onto the screen 
via a more complex module later on.


Would like to hear some feedback since it's my first contribution in rust :)
