### PR TITLE
When shooting, the bullet is displayed instead of the player, erasing…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,4 @@ pub mod shot;
 
 pub const NUM_ROWS: usize = 20;
 pub const NUM_COLS: usize = 40;
+pub const PLAYER_CHAR_HEIGHT: usize = 6; // We use "A" as a player char in the frame, it ~6 pixels height

--- a/src/shot.rs
+++ b/src/shot.rs
@@ -1,4 +1,7 @@
-use crate::frame::{Drawable, Frame};
+use crate::{
+    frame::{Drawable, Frame},
+    NUM_ROWS, PLAYER_CHAR_HEIGHT,
+};
 use rusty_time::Timer;
 use std::time::Duration;
 
@@ -38,6 +41,13 @@ impl Shot {
 
 impl Drawable for Shot {
     fn draw(&self, frame: &mut Frame) {
-        frame[self.x][self.y] = if self.exploding { '*' } else { '|' };
+        let bottom_bound_y = NUM_ROWS - PLAYER_CHAR_HEIGHT;
+        let pos_y = if self.y >= bottom_bound_y {
+            bottom_bound_y
+        } else {
+            self.y
+        };
+
+        frame[self.x][pos_y] = if self.exploding { '*' } else { '|' };
     }
 }


### PR DESCRIPTION
When shooting, the bullet is displayed instead of the player, erasing the player's position in the frame, to fix this character height is calculated to avoid to print the shot over player's position.

![image](https://github.com/CleanCut/invaders/assets/13221281/4a2d2656-6cd4-4090-8cf2-9b35cc83440b)
